### PR TITLE
Fix #275 gin storage of n_channels in model

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -156,7 +156,7 @@ def main(argv):
         )
 
     # create model
-    model = rave.RAVE(n_channels=FLAGS.channels)
+    model = rave.RAVE()
     if FLAGS.derivative:
         model.integrator = rave.dataset.get_derivator_integrator(model.sr)[1]
 


### PR DESCRIPTION
This fixes export when models are trained with`--channels 2`. Generation with these models still doesn't work.