### PR TITLE
rave generate improvements

### DIFF
--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -29,7 +29,7 @@ def get_audio_files(path):
         audio_files.extend([(path, os.path.join(root, f)) for f in valid_files])
     return audio_files
 
-
+@torch.no_grad()
 def main(argv):
     torch.set_float32_matmul_precision('high')
     cc.use_cached_conv(FLAGS.stream)
@@ -117,7 +117,6 @@ def main(argv):
             out = model.forward(x[None])
 
         # save file
-        out_path = re.sub(d, "", f)
         out_path = os.path.join(FLAGS.out_path, f)
         os.makedirs(os.path.dirname(out_path), exist_ok=True)
         torchaudio.save(out_path, out[0].cpu(), sample_rate=model.sr)


### PR DESCRIPTION
- Added `torch.no_grad` to `main`. Without this, this gradients accumulate when doing inference and the memory consumption on longer files explode. Without this fix I was getting OOM errors on 24gb of vram with a 17-minute file. With this change, roughly 9gb of VRAM is used with the same file (and ~1gb when using a small chunk size)
- removed the `re.sub`. This isn't being used and caused `rave generate` to fail with windows filepaths (due to `\` being incorrectly read as escape characters)