### PR TITLE
fix broken tutorial link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Please check the FAQ before posting an issue!
 **RAVE VST** RAVE VST for Windows, Mac and Linux is available as beta on the [corresponding Forum IRCAM webpage](https://forum.ircam.fr/projects/detail/rave-vst/). For problems, please write an issue here or [on the Forum IRCAM discussion page](https://discussion.forum.ircam.fr/c/rave-vst/651).
 
 **Tutorials** : new tutorials are available on the Forum IRCAM webpage, and video versions are coming soon!
-- [Tutorial: Neural Synthesis in a DAW with RAVE](https://forum.ircam.fr/article/detail/neural-synthesis-in-a-daw-with-rave/)
+- [Tutorial: Neural Synthesis in a DAW with RAVE](https://forum.ircam.fr/article/detail/tutorial-neural-synthesis-in-a-daw-with-rave/)
 - [Tutorial: Neural Synthesis in Max 8 with RAVE](https://forum.ircam.fr/article/detail/tutorial-neural-synthesis-in-max-8-with-rave/)
 - [Tutorial: Training RAVE models on custom data](https://forum.ircam.fr/article/detail/training-rave-models-on-custom-data/)
 


### PR DESCRIPTION
- fixes https://github.com/acids-ircam/RAVE/issues/315

> In the README, the "Tutorial: Neural Synthesis in a DAW with RAVE" link is broken:
> 
> * [forum.ircam.fr/article/detail/neural-synthesis-in-a-daw-with-rave](https://forum.ircam.fr/article/detail/neural-synthesis-in-a-daw-with-rave/)
> 
> Searching the forum, it seems it should be:
> 
> * [forum.ircam.fr/article/detail/tutorial-neural-synthesis-in-a-daw-with-rave](https://forum.ircam.fr/article/detail/tutorial-neural-synthesis-in-a-daw-with-rave/)
> 
> https://github.com/acids-ircam/RAVE/blob/44498a0d6ea80349be5cf65ccd9e8d64a0edfbdb/README.md?plain=1#L15-L18
>
>_Originally posted by @0xdevalias in https://github.com/acids-ircam/RAVE/issues/315_