### PR TITLE
generate: fix deprecations in get_valid_extensions

### DIFF
--- a/rave/core.py
+++ b/rave/core.py
@@ -569,13 +569,15 @@ class ModelCheckpoint(pl.callbacks.ModelCheckpoint):
 
 def get_valid_extensions():
     import torchaudio
-    backend = torchaudio.get_audio_backend()
-    if backend in ["sox_io", "sox"]:
-        return ['.'+f for f in torchaudio.utils.sox_utils.list_read_formats()]
-    elif backend == "ffmpeg":
-        return ['.'+f for f in torchaudio.utils.ffmpeg_utils.get_audio_decoders()]
-    elif backend == "soundfile":
-        return ['.wav', '.flac', '.ogg', '.aiff', '.aif', '.aifc']
+    backends = torchaudio.list_audio_backends()
+    formats = set()
+    if "sox_io" in backends or "sox" in backends:
+        formats = formats.union(['.'+f for f in torchaudio.utils.sox_utils.list_read_formats()])
+    if "ffmpeg" in backends:
+        formats = formats.union(['.'+f for f in torchaudio.utils.ffmpeg_utils.get_audio_decoders()])
+    if "soundfile" in backends:
+        formats = formats.union(['.wav', '.flac', '.ogg', '.aiff', '.aif', '.aifc'])
+    return list(formats)
 
 accelerator_map = {
     'cpu': pl.accelerators.CPUAccelerator, 

--- a/rave/scripts/generate.py
+++ b/rave/scripts/generate.py
@@ -14,7 +14,7 @@ from absl import flags, app, logging
 from itertools import product
 from pathlib import Path
 
-valid_exts = [".wav", ".aif", ".aiff", ".opus", ".mp3", ".aac"]
+valid_exts = rave.core.get_valid_extensions()
 flags.DEFINE_multi_string('model', required=True, default=None, help="model path")
 flags.DEFINE_multi_string('input', required=True, default=None, help="model inputs (file or folder)")
 flags.DEFINE_multi_enum('mode', 'stream', ['stream', 'full'], help="streaming mode")


### PR DESCRIPTION
Replaces torchaudio `get_audio_backend` with `list_available_backends`. The latter is also deprecated and will be removed in torch 2.9 (in favor of torchcodec), but since this branch pins torch to 2.5, I thought it was worth to open a PR.

At least on my system, the list of available formats returned by this function is huge:

<details>

```python
['.pcm_s24be', '.dfpwm', '.adpcm_ima_amv', '.flac', '.metasound', '.g722', '.tak', '.sndt', '.wsaud', '.eac3', '.adpcm_afc', '.libopus', '.pcm_u16le', '.3g2', '.cvsd', '.wsd', '.xma2', '.wav', '.adpcm_ea_r2', '.xma1', '.aptx_hd', '.pcm_alaw', '.pcm_f24le', '.mxf_opatom', '.mp4', '.pcm_s8', '.dsd_msbf_planar', '.libvorbis', '.adpcm_ima_smjpeg', '.wtv', '.nist', '.m4a', '.sonic', '.anb', '.adpcm_ima_ea_eacs', '.mj2', '.mp3on4', '.cdda', '.mpg', '.3gp', '.pcm_s64le', '.fastaudio', '.adpcm_ea_r3', '.f64', '.xi', '.nellymoser', '.f8', '.ismv', '.on2avc', '.ra', '.amr-wb', '.wma', '.ilbc', '.mace6', '.au', '.adpcm_ima_dk4', '.adpcm_zork', '.mlp', '.pcm_s24le', '.flv', '.s2', '.binkaudio_dct', '.sndfile', '.nsp', '.mpeg', '.pcm_s24le_planar', '.g729', '.lpc', '.mp3on4float', '.htk', '.u16', '.m4v', '.ima', '.amr-nb', '.pcm_s16be_planar', '.wmapro', '.pcm_s32be', '.s3', '.txw', '.mpegts', '.adpcm_ima_oki', '.u8', '.rso', '.uw', '.adpcm_thp_le', '.mkv', '.mxf', '.wmav2', '.ub', '.gsm', '.adpcm_ima_dk3', '.pcm_f16le', '.adpcm_ima_moflex', '.aptx', '.w64', '.3gpp2', '.caf', '.mpc2k', '.u2', '.speex', '.3gpp', '.adx', '.derf_dpcm', '.vorbis', '.vms', '.imc', '.sw', '.hcom', '.g726le', '.8svx_exp', '.awb', '.cdr', '.ws_snd1', '.dvd', '.cvs', '.lpc10', '.wavpcm', '.avi', '.pcm_vidc', '.adpcm_ima_iss', '.mpc7', '.adpcm_ima_apm', '.wavesynth', '.adpcm_agm', '.ralf', '.adpcm_xa', '.mpc8', '.s16', '.vcd', '.mp3adu', '.libgsm_ms', '.qdm2', '.ossdsp', '.u32', '.adpcm_ima_alp', '.aifc', '.sipr', '.comfortnoise', '.dsd_lsbf', '.pcm_u16be', '.atrac3plusal', '.prc', '.dvaudio', '.adpcm_ct', '.gxf', '.tta', '.dss_sp', '.adpcm_argo', '.ogg', '.sln', '.mp3adufloat', '.ircam', '.real_144', '.ast', '.qcelp', '.lu', '.adpcm_ea_maxis_xa', '.dst', '.adpcm_ima_ssi', '.interplayacm', '.snd', '.shorten', '.acelp.kelvin', '.smp', '.svcd', '.s8', '.adpcm_sbpro_3', '.opus', '.sox', '.libopencore_amrwb', '.gsrt', '.evrc', '.paf_audio', '.wv', '.adpcm_ima_ws', '.bmv_audio', '.interplay_dpcm', '.wmavoice', '.al', '.smackaud', '.adpcm_ea_r1', '.ul', '.vag', '.voc', '.maud', '.pcm_dvd', '.pcm_f32le', '.f4v', '.atrac9', '.dsd_lsbf_planar', '.adpcm_aica', '.qdmc', '.pcm_lxf', '.spx', '.pcm_s16le', '.pcm_u24be', '.binkaudio_rdft', '.aif', '.xa', '.fap', '.pvf', '.wmav1', '.oga', '.pcm_u32le', '.pcm_s16be', '.dts', '.pcm_u24le', '.hca', '.atrac3', '.mat5', '.adpcm_sbpro_2', '.alac', '.null', '.adpcm_ima_apc', '.mace3', '.pcm_mulaw', '.pcm_s64be', '.mp1', '.webm', '.adpcm_4xm', '.pcm_f64be', '.sndr', '.ac3', '.pcm_bluray', '.als', '.aac_latm', '.spdif', '.twinvq', '.adpcm_ima_dat4', '.gsm_ms', '.s4', '.pulseaudio', '.amrnb', '.avr', '.wavpack', '.nut', '.atrac3al', '.u24', '.g723_1', '.sdx2_dpcm', '.vob', '.amrwb', '.dsf', '.wve', '.adpcm_yamaha', '.apm', '.pcm_f64le', '.asf', '.amb', '.truespeech', '.dsicinaudio', '.aptxhd', '.wmalossless', '.cook', '.rm', '.pcm_s32le_planar', '.atrac3plus', '.adpcm_dtk', '.adts', '.3gp2', '.dvms', '.s32', '.dolby_e', '.adpcm_ima_cunning', '.pcm_f32be', '.f32', '.s24', '.sds', '.adpcm_ea_xas', '.8svx', '.iac', '.isma', '.alsa', '.adpcm_mtaf', '.adpcm_ea', '.pcm_sga', '.atrac1', '.g726', '.dsd_msbf', '.adpcm_sbpro_4', '.sb', '.truehd', '.adpcm_swf', '.pcm_s8_planar', '.sl', '.aiff', '.vox', '.s302m', '.adpcm_ima_mtf', '.libgsm', '.siren', '.ffmpeg', '.ism', '.libopencore_amrnb', '.cvu', '.adpcm_ima_qt', '.s1', '.adpcm_vima', '.aiffc', '.smjpeg', '.mat4', '.mp1float', '.pcm_u32be', '.psp', '.f4', '.vmdaudio', '.real_288', '.mp2', '.m4b', '.fssd', '.8svx_fib', '.gremlin_dpcm', '.u1', '.mp3float', '.pcm_s24daud', '.sf', '.dat', '.sph', '.ape', '.pcm_s16le_planar', '.kvag', '.sou', '.dff', '.adpcm_adx', '.sol_dpcm', '.argo_asf', '.oss', '.adpcm_psx', '.xan_dpcm', '.aac', '.la', '.u3', '.adpcm_ima_rad', '.adpcm_ima_wav', '.adpcm_thp', '.ac3_fixed', '.paf', '.pcm_u8', '.raw', '.pcm_s32le', '.mp2float', '.libspeex', '.mov', '.adpcm_ima_ea_sead', '.mp3', '.adpcm_ms', '.mat', '.sd2', '.roq_dpcm', '.aac_fixed', '.sbc', '.u4', '.dca']
```
</details>
